### PR TITLE
Add IDEControllerDevices to Config and tests

### DIFF
--- a/device.go
+++ b/device.go
@@ -189,6 +189,10 @@ func (config *Config) appendDevices() error {
 			for _, d := range config.SCSIControllerDevices {
 				config.devices = append(config.devices, d)
 			}
+		case "IDEControllerDevices": // controllers have to be before blkdev
+			for _, d := range config.IDEControllerDevices {
+				config.devices = append(config.devices, d)
+			}
 		}
 	}
 

--- a/ide-controller_test.go
+++ b/ide-controller_test.go
@@ -3,15 +3,16 @@ package qcli
 import "testing"
 
 var (
-	deviceIDEControllerPIIX3Str       = "-device piix3-ide,id=ide0,addr=0x1e,bus=pcie.0"
-	deviceIDEControllerPIIX4Str       = "-device piix4-ide,id=ide0,addr=0x1e,bus=pcie.0"
-	deviceIDEControllerAHCIStr        = "-device ich9-ahci,id=ide0,addr=0x1e,bus=pcie.0"
-	deviceIDEControllerAHCIBusAddrStr = "-device ich9-ahci,id=ide0,addr=0x1e,bus=pcie.1,romfile=romfile,rombar=1024,multifunction=on"
+	deviceIDEControllerPIIX3Str       = "-device piix3-ide,id=ide0,addr=0x1e,bus=ide.0"
+	deviceIDEControllerPIIX4Str       = "-device piix4-ide,id=ide0,addr=0x1e,bus=ide.0"
+	deviceIDEControllerAHCIStr        = "-device ich9-ahci,id=ide0,addr=0x1e,bus=ide.0"
+	deviceIDEControllerAHCIBusAddrStr = "-device ich9-ahci,id=ide0,addr=0x1e,bus=ide.1,romfile=romfile,rombar=1024,multifunction=on"
 )
 
 func TestAppendDeviceIDEController(t *testing.T) {
 	ideCon := IDEControllerDevice{
 		ID:     "ide0",
+		Bus:    "ide.0",
 		Driver: ICH9AHCIController,
 	}
 	testAppend(ideCon, deviceIDEControllerAHCIStr, t)
@@ -23,10 +24,39 @@ func TestAppendDeviceIDEController(t *testing.T) {
 	testAppend(ideCon, deviceIDEControllerPIIX4Str, t)
 
 	ideCon.Driver = ICH9AHCIController
-	ideCon.Bus = "pcie.1"
+	ideCon.Bus = "ide.1"
 	ideCon.Addr = "0x5"
 	ideCon.ROMFile = "romfile"
 	ideCon.ROMBar = "1024"
 	ideCon.Multifunction = true
 	testAppend(ideCon, deviceIDEControllerAHCIBusAddrStr, t)
+}
+
+func TestAppendDeviceIDEControllerAndIDECDROM(t *testing.T) {
+	conf := &Config{
+		IDEControllerDevices: []IDEControllerDevice{
+			IDEControllerDevice{
+				ID:     "ide0",
+				Driver: ICH9AHCIController,
+				Bus:    "ide.0",
+			},
+		},
+		BlkDevices: []BlockDevice{
+			BlockDevice{
+				Driver:    IDECDROM,
+				Interface: NoInterface,
+				ID:        "cdrom0",
+				AIO:       Threads,
+				Serial:    "ubuntu.iso",
+				File:      "ubuntu.iso",
+				Format:    RAW,
+				ReadOnly:  true,
+				Media:     "cdrom",
+				BootIndex: 0,
+				Bus:       "ide.0",
+			},
+		},
+	}
+	expected := deviceIDEControllerAHCIStr + " " + deviceBlockIDECDRom
+	testConfig(conf, expected, t)
 }

--- a/qemu.go
+++ b/qemu.go
@@ -244,6 +244,7 @@ type Config struct {
 	PCIeRootPortDevices   []PCIeRootPortDevice   `yaml:"pcie-root-port-devices"`
 	UEFIFirmwareDevices   []UEFIFirmwareDevice   `yaml:"uefi-firmware-devices"`
 	SCSIControllerDevices []SCSIControllerDevice `yaml:"scsi-controller-devices"`
+	IDEControllerDevices  []IDEControllerDevice  `yaml:"ide-controller-devices"`
 
 	// RTC is the qemu Real Time Clock configuration
 	RTC RTC `yaml:"real-time-clock"`


### PR DESCRIPTION
Add a top-level IDEControllerDevices field to the Config object Add tests for controller+ide-cdrom device