### PR TITLE
Switch BootIndex to type string for easy unset testing

### DIFF
--- a/blockdev.go
+++ b/blockdev.go
@@ -99,7 +99,7 @@ type BlockDevice struct {
 	Format    BlockDeviceFormat    `yaml:"format"`
 	SCSI      bool                 `yaml:"scsi"`
 	WCE       bool                 `yaml:"write-cache"`
-	BootIndex *int                 `yaml:"bootindex"`
+	BootIndex string               `yaml:"bootindex"`
 
 	// Media is a hint about the what type of content on the disk, e.g media=cdrom
 	Media string `yaml:"media"`
@@ -234,8 +234,8 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf("serial=%s", blkdev.ID))
 	}
 
-	if blkdev.BootIndex != nil {
-		deviceParams = append(deviceParams, fmt.Sprintf("bootindex=%d", *blkdev.BootIndex))
+	if blkdev.BootIndex != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("bootindex=%s", blkdev.BootIndex))
 	}
 
 	if blkdev.Driver == VirtioBlock {

--- a/blockdev_test.go
+++ b/blockdev_test.go
@@ -66,7 +66,7 @@ func TestAppendDeviceBlockVirtioCDROM(t *testing.T) {
 		Format:    RAW,
 		ReadOnly:  true,
 		Media:     "cdrom",
-		BootIndex: ValuePtr(0),
+		BootIndex: "0",
 	}
 	if blkdev.Transport.isVirtioCCW(nil) {
 		blkdev.DevNo = DevNo
@@ -85,7 +85,7 @@ func TestAppendDeviceBlockIDECDROM(t *testing.T) {
 		Format:    RAW,
 		ReadOnly:  true,
 		Media:     "cdrom",
-		BootIndex: ValuePtr(0),
+		BootIndex: "0",
 		Bus:       "ide.0",
 	}
 	if blkdev.Transport.isVirtioCCW(nil) {
@@ -104,7 +104,7 @@ func TestAppendDeviceBlockSCSIHD(t *testing.T) {
 		Serial:       "root-disk",
 		File:         "root-disk.qcow",
 		Format:       QCOW2,
-		BootIndex:    ValuePtr(1),
+		BootIndex:    "1",
 		Bus:          "scsi0.0",
 		Cache:        CacheModeUnsafe,
 		Discard:      DiscardUnmap,

--- a/example/convert-cluster.go
+++ b/example/convert-cluster.go
@@ -19,7 +19,7 @@ type QemuDisk struct {
 	Type      string `yaml:"type"`
 	BlockSize int    `yaml:"blocksize"`
 	BusAddr   string `yaml:"addr"`
-	BootIndex *int   `yaml:"bootindex"`
+	BootIndex string `yaml:"bootindex"`
 	ReadOnly  bool   `yaml:"read-only"`
 	Serial    string `yaml:"serial"`
 }
@@ -98,7 +98,7 @@ type NicDef struct {
 	ID        string     `yaml:"id"`
 	Mac       string     `yaml:"mac"`
 	Ports     []PortRule `yaml:"ports"`
-	BootIndex *int       `yaml:"bootindex"`
+	BootIndex string     `yaml:"bootindex"`
 }
 
 type VMNic struct {
@@ -110,7 +110,7 @@ type VMNic struct {
 	NetIFName  string
 	NetType    string
 	NetAddr    string
-	BootIndex  *int
+	BootIndex  string
 	Ports      []PortRule
 }
 

--- a/example/run-vms.go
+++ b/example/run-vms.go
@@ -88,7 +88,7 @@ func getFullConfig() qcli.Config {
 				Cache:         qcli.CacheModeUnsafe,
 				Discard:       qcli.DiscardUnmap,
 				DetectZeroes:  qcli.DetectZeroesUnmap,
-				BootIndex:     0,
+				BootIndex:     "0",
 			},
 		},
 		NetDevices: []qcli.NetDevice{

--- a/ide-controller_test.go
+++ b/ide-controller_test.go
@@ -52,7 +52,7 @@ func TestAppendDeviceIDEControllerAndIDECDROM(t *testing.T) {
 				Format:    RAW,
 				ReadOnly:  true,
 				Media:     "cdrom",
-				BootIndex: ValuePtr(0),
+				BootIndex: "0",
 				Bus:       "ide.0",
 			},
 		},

--- a/netdevice.go
+++ b/netdevice.go
@@ -298,7 +298,7 @@ type NetDevice struct {
 	McastSocket NetDeviceMcastSocket `yaml:"mcast-socket"`
 
 	// bootindex
-	BootIndex int `yaml:"bootindex"`
+	BootIndex string `yaml:"bootindex"`
 }
 
 // VirtioNetTransport is a map of the virtio-net device name that corresponds
@@ -388,6 +388,10 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 		if err == nil && addr >= 0 {
 			deviceParams = append(deviceParams, fmt.Sprintf("addr=0x%02x", addr))
 		}
+	}
+
+	if netdev.BootIndex != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("bootindex=%s", netdev.BootIndex))
 	}
 
 	if strings.HasPrefix(string(driver), "virtio") {

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -732,7 +732,7 @@ func fullVMConfig() *Config {
 				Cache:         CacheModeUnsafe,
 				Discard:       DiscardUnmap,
 				DetectZeroes:  DetectZeroesUnmap,
-				BootIndex:     ValuePtr(0),
+				BootIndex:     "0",
 			},
 		},
 		NetDevices: []NetDevice{

--- a/qemuindex.go
+++ b/qemuindex.go
@@ -90,9 +90,3 @@ func (qti QemuTypeIndex) NextNetIndex() int {
 func (qti QemuTypeIndex) SetNetIndex(index int) error {
 	return qti.Set("net", index)
 }
-
-func ValuePtr(index int) *int {
-	val := new(int)
-	*val = index
-	return val
-}


### PR DESCRIPTION
- Drop ValuePtr() bits
- Switch all BootIndex values to strings in tests
- Fix blockdev bootindex parameter
- Implement netdev bootindex parameter