### PR TITLE
Add smbios support

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -228,6 +228,9 @@ type Config struct {
 	// Machine
 	Machine Machine `yaml:"machine"`
 
+	// SMBIOS
+	SMBIOS SMBIOSInfo `yaml:"smbios"`
+
 	// QMPSockets is a slice of QMP socket description.
 	QMPSockets []QMPSocket `yaml:"qmp-sockets"`
 
@@ -645,6 +648,9 @@ func ConfigureParams(config *Config, logger QMPLog) ([]string, error) {
 	config.appendCPUModel()
 	config.appendSpice()
 	config.appendTPM()
+	if err := config.appendSMBIOSInfo(); err != nil {
+		return []string{}, err
+	}
 	err = config.appendQMPSockets()
 	if err != nil {
 		return []string{}, err

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -65,6 +65,16 @@ func testConfigAppend(config *Config, structure interface{}, expected string, t 
 		objParams := s.QemuParams(config)
 		config.qemuParams = append(config.qemuParams, objParams...)
 
+	case TPMDevice:
+		config.TPM = s
+		config.appendTPM()
+
+	case SMBIOSInfo:
+		config.SMBIOS = s
+		if err := config.appendSMBIOSInfo(); err != nil {
+			t.Fatalf("Failed ot append SMBIOS '%v', error: %s", s, err)
+		}
+
 	case Knobs:
 		config.Knobs = s
 		config.appendKnobs()

--- a/smbios.go
+++ b/smbios.go
@@ -1,0 +1,405 @@
+package qcli
+
+import (
+	"fmt"
+	"strings"
+)
+
+/*
+smbios:
+  file:
+  bios:
+  system:
+  baseboard:
+  chassis:
+  processors:
+  - processor
+  - processor
+  memory:
+  - memory
+  - memory
+*/
+
+type SMBIOSInfo struct {
+	File       string             `yaml:"file,omitempty"`       // -smbios file
+	BIOS       SMTableBIOS        `yaml:"bios,omitempty"`       // -smbios type=0
+	System     SMTableSystem      `yaml:"system,omitempty"`     // -smbios type=1
+	Baseboard  SMTableBaseboard   `yaml:"baseboard,omitempty"`  // -smbios type=2
+	Chassis    SMTableChassis     `yaml:"chassis,omitempty"`    // -smbios type=3
+	Processors []SMTableProcessor `yaml:"processors,omitempty"` // -smbios type=4
+	Memory     []SMTableMemory    `yaml:"memory,omitempty"`     // -smbios type=17
+}
+
+const SMTableBIOSType = 0
+
+type SMTableBIOS struct {
+	Vendor  string `yaml:"vendor,omitempty"`
+	Version string `yaml:"version,omitempty"`
+	Date    string `yaml:"date,omitempty"`
+	Release string `yaml:"release,omitempty"`
+	UEFI    string `yaml:"uefi,omitempty"`
+}
+
+func (table SMTableBIOS) Valid() error {
+	if table.Release != "" {
+		var major int
+		var minor int
+		_, err := fmt.Sscanf(table.Release, "%d.%d", &major, &minor)
+		if err != nil {
+			return fmt.Errorf("SMTableBIOS Type=0 Release field is not in <digit>.<digit> format")
+		}
+	}
+	if table.UEFI != "" {
+		val := strings.ToLower(table.UEFI)
+		if val != "on" && val != "off" {
+			return fmt.Errorf("SMTableBIOS Type=0 UEFI field is not 'on' or 'off': %s", table.UEFI)
+		}
+	}
+	return nil
+}
+
+func (table SMTableBIOS) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableBIOSType)
+
+	if table.Vendor != "" {
+		tableParams = append(tableParams, "vendor="+table.Vendor)
+	}
+	if table.Version != "" {
+		tableParams = append(tableParams, "version="+table.Version)
+	}
+	if table.Date != "" {
+		tableParams = append(tableParams, "date="+table.Date)
+	}
+	if table.Release != "" {
+		tableParams = append(tableParams, "release="+table.Release)
+	}
+	if table.UEFI != "" {
+		tableParams = append(tableParams, "uefi="+table.UEFI)
+	}
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	// fmt.Printf("SMTableBIOS: table=%v tparams=%v qparams=%v\n", table, tableParams, qemuParams)
+	return qemuParams
+}
+
+const SMTableSystemType = 1
+
+type SMTableSystem struct {
+	Manufacturer string `yaml:"manufacturer,omitempty"`
+	Product      string `yaml:"product,omitempty"`
+	Version      string `yaml:"version,omitempty"`
+	Serial       string `yaml:"serial,omitempty"`
+	UUID         string `yaml:"uuid,omitempty"`
+	SKU          string `yaml:"sku,omitempty"`
+	Family       string `yaml:"family,omitempty"`
+}
+
+func (table SMTableSystem) Valid() error {
+	// no format requirements
+	return nil
+}
+
+func (table SMTableSystem) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableSystemType)
+
+	if table.Manufacturer != "" {
+		tableParams = append(tableParams, "manufacturer="+table.Manufacturer)
+	}
+	if table.Product != "" {
+		tableParams = append(tableParams, "product="+table.Product)
+	}
+	if table.Version != "" {
+		tableParams = append(tableParams, "version="+table.Version)
+	}
+	if table.Serial != "" {
+		tableParams = append(tableParams, "serial="+table.Serial)
+	}
+	if table.UUID != "" {
+		tableParams = append(tableParams, "uuid="+table.UUID)
+	}
+	if table.SKU != "" {
+		tableParams = append(tableParams, "sku="+table.SKU)
+	}
+	if table.Family != "" {
+		tableParams = append(tableParams, "family="+table.Family)
+	}
+
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	return qemuParams
+}
+
+const SMTableBaseboardType = 2
+
+type SMTableBaseboard struct {
+	Manufacturer string `yaml:"manufacturer,omitempty"`
+	Product      string `yaml:"product,omitempty"`
+	Version      string `yaml:"version,omitempty"`
+	Serial       string `yaml:"serial,omitempty"`
+	Asset        string `yaml:"asset,omitempty"`
+	Location     string `yaml:"location,omitempty"`
+}
+
+func (table SMTableBaseboard) Valid() error {
+	// no format requirements
+	return nil
+}
+
+func (table SMTableBaseboard) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableBaseboardType)
+
+	if table.Manufacturer != "" {
+		tableParams = append(tableParams, "manufacturer="+table.Manufacturer)
+	}
+	if table.Product != "" {
+		tableParams = append(tableParams, "product="+table.Product)
+	}
+	if table.Version != "" {
+		tableParams = append(tableParams, "version="+table.Version)
+	}
+	if table.Serial != "" {
+		tableParams = append(tableParams, "serial="+table.Serial)
+	}
+	if table.Asset != "" {
+		tableParams = append(tableParams, "asset="+table.Asset)
+	}
+	if table.Location != "" {
+		tableParams = append(tableParams, "location="+table.Location)
+	}
+
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	return qemuParams
+}
+
+const SMTableChassisType = 3
+
+type SMTableChassis struct {
+	Manufacturer string `yaml:"manufacturer,omitempty"`
+	Version      string `yaml:"version,omitempty"`
+	Serial       string `yaml:"serial,omitempty"`
+	Asset        string `yaml:"asset,omitempty"`
+	SKU          string `yaml:"sku,omitempty"`
+}
+
+func (table SMTableChassis) Valid() error {
+	// no format requirements
+	return nil
+}
+
+func (table SMTableChassis) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableChassisType)
+
+	if table.Manufacturer != "" {
+		tableParams = append(tableParams, "manufacturer="+table.Manufacturer)
+	}
+	if table.Version != "" {
+		tableParams = append(tableParams, "version="+table.Version)
+	}
+	if table.Serial != "" {
+		tableParams = append(tableParams, "serial="+table.Serial)
+	}
+	if table.Asset != "" {
+		tableParams = append(tableParams, "asset="+table.Asset)
+	}
+	if table.SKU != "" {
+		tableParams = append(tableParams, "sku="+table.SKU)
+	}
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	return qemuParams
+}
+
+const SMTableProcessorType = 4
+
+type SMTableProcessor struct {
+	SocketPrefix string `yaml:"socket-prefix,omitempty"`
+	Manufacturer string `yaml:"manufacturer,omitempty"`
+	Version      string `yaml:"version,omitempty"`
+	Serial       string `yaml:"serial,omitempty"`
+	Asset        string `yaml:"asset,omitempty"`
+	Part         string `yaml:"part,omitempty"`
+}
+
+func (table SMTableProcessor) Valid() error {
+	// no format requirements
+	return nil
+}
+
+func (table SMTableProcessor) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableProcessorType)
+
+	if table.SocketPrefix != "" {
+		tableParams = append(tableParams, "sock_pfx="+table.SocketPrefix)
+	}
+	if table.Manufacturer != "" {
+		tableParams = append(tableParams, "manufacturer="+table.Manufacturer)
+	}
+	if table.Version != "" {
+		tableParams = append(tableParams, "version="+table.Version)
+	}
+	if table.Serial != "" {
+		tableParams = append(tableParams, "serial="+table.Serial)
+	}
+	if table.Asset != "" {
+		tableParams = append(tableParams, "asset="+table.Asset)
+	}
+	if table.Part != "" {
+		tableParams = append(tableParams, "part="+table.Part)
+	}
+
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	return qemuParams
+}
+
+const SMTableMemoryType = 17
+
+type SMTableMemory struct {
+	LocationPrefix string `yaml:"location-prefix,omitempty"`
+	Bank           string `yaml:"bank,omitempty"`
+	Manufacturer   string `yaml:"manufacturer,omitempty"`
+	Serial         string `yaml:"serial,omitempty"`
+	Asset          string `yaml:"asset,omitempty"`
+	Part           string `yaml:"part,omitempty"`
+	Speed          string `yaml:"speed,omitempty"`
+}
+
+func (table SMTableMemory) Valid() error {
+	if table.Speed != "" {
+		var speed int
+		_, err := fmt.Sscanf(table.Speed, "%d", &speed)
+		if err != nil {
+			return fmt.Errorf("SMTableMemory Type=17 Speed field must be a number, found: %s", table.Speed)
+		}
+	}
+	return nil
+}
+
+func (table SMTableMemory) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var tableParams []string
+	typeParam := fmt.Sprintf("type=%d", SMTableMemoryType)
+
+	if table.LocationPrefix != "" {
+		tableParams = append(tableParams, "loc_pfx="+table.LocationPrefix)
+	}
+	if table.Bank != "" {
+		tableParams = append(tableParams, "bank="+table.Bank)
+	}
+	if table.Manufacturer != "" {
+		tableParams = append(tableParams, "manufacturer="+table.Manufacturer)
+	}
+	if table.Serial != "" {
+		tableParams = append(tableParams, "serial="+table.Serial)
+	}
+	if table.Asset != "" {
+		tableParams = append(tableParams, "asset="+table.Asset)
+	}
+	if table.Part != "" {
+		tableParams = append(tableParams, "part="+table.Part)
+	}
+	if table.Speed != "" {
+		tableParams = append(tableParams, "speed="+table.Speed)
+	}
+	if len(tableParams) > 0 {
+		qemuParams = append(qemuParams, "-smbios")
+		tableParams = append([]string{typeParam}, tableParams...)
+		qemuParams = append(qemuParams, strings.Join(tableParams, ","))
+	}
+	return qemuParams
+}
+
+/*
+type SMBIOSInfo struct {
+	File       string             `yaml:"file,omitempty"`       // -smbios file
+	BIOS       SMTableBIOS        `yaml:"bios,omitempty"`       // -smbios type=0
+	System     SMTableSystem      `yaml:"system,omitempty"`     // -smbios type=1
+	Baseboard  SMTableBaseboard   `yaml:"baseboard,omitempty"`  // -smbios type=2
+	Chassis    SMTableChassis     `yaml:"chassis,omitempty"`    // -smbios type=3
+	Processors []SMTableProcessor `yaml:"processors,omitempty"` // -smbios type=4
+	Memory     []SMTableMemory    `yaml:"memory,omitempty"`     // -smbios type=17
+}
+*/
+
+// Valid returns true if the SMBIOSInfo structure is valid and complete.
+func (smb SMBIOSInfo) Valid() error {
+	if err := smb.BIOS.Valid(); err != nil {
+		return err
+	}
+	if err := smb.System.Valid(); err != nil {
+		return err
+	}
+	if err := smb.Baseboard.Valid(); err != nil {
+		return err
+	}
+	if err := smb.Chassis.Valid(); err != nil {
+		return err
+	}
+	for _, proc := range smb.Processors {
+		if err := proc.Valid(); err != nil {
+			return err
+		}
+	}
+	for _, mem := range smb.Memory {
+		if err := mem.Valid(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// QemuParams returns the qemu parameters built out of the SMBIOSInfo object
+func (smb SMBIOSInfo) QemuParams(config *Config) []string {
+	var qemuParams []string
+
+	if smb.File != "" {
+		qemuParams = append(qemuParams, "-smbios", "file="+smb.File)
+	}
+	qemuParams = append(qemuParams, smb.BIOS.QemuParams(config)...)
+	qemuParams = append(qemuParams, smb.System.QemuParams(config)...)
+	qemuParams = append(qemuParams, smb.Baseboard.QemuParams(config)...)
+	qemuParams = append(qemuParams, smb.Chassis.QemuParams(config)...)
+	for _, proc := range smb.Processors {
+		qemuParams = append(qemuParams, proc.QemuParams(config)...)
+	}
+	for _, mem := range smb.Memory {
+		qemuParams = append(qemuParams, mem.QemuParams(config)...)
+	}
+
+	return qemuParams
+}
+
+func (config *Config) appendSMBIOSInfo() error {
+	//fmt.Printf("config called appendSMBIOSInfo()\n")
+	if err := config.SMBIOS.Valid(); err != nil {
+		return err
+	}
+	config.qemuParams = append(config.qemuParams, config.SMBIOS.QemuParams(config)...)
+	return nil
+}

--- a/smbios_test.go
+++ b/smbios_test.go
@@ -1,0 +1,128 @@
+package qcli
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	smbFile           = "-smbios file=foo"
+	smbType0Bios      = "-smbios type=0,vendor=Vendor,version=Version,date=Date,release=1.0,uefi=on"
+	smbType1System    = "-smbios type=1,manufacturer=Manufacturer,product=Product,version=Version,serial=Serial,uuid=UUID,sku=SKU,family=Family"
+	smbType2Baseboard = "-smbios type=2,manufacturer=Manufacturer,product=Product,version=Version,serial=Serial,asset=Asset,location=Location"
+	smbType3Chassis   = "-smbios type=3,manufacturer=Manufacturer,version=Version,serial=Serial,asset=Asset,sku=SKU"
+	smbType4Processor = "-smbios type=4,sock_pfx=SocketPrefix,manufacturer=Manufacturer,version=Version,serial=Serial,asset=Asset,part=Part"
+	smbType17Memory   = "-smbios type=17,loc_pfx=LocationPrefix,bank=Bank,manufacturer=Manufacturer,serial=Serial,asset=Asset,part=Part,speed=3600"
+)
+
+var bios = SMTableBIOS{
+	Vendor:  "Vendor",
+	Version: "Version",
+	Date:    "Date",
+	Release: "1.0",
+	UEFI:    "on",
+}
+var system = SMTableSystem{
+	Manufacturer: "Manufacturer",
+	Product:      "Product",
+	Version:      "Version",
+	Serial:       "Serial",
+	UUID:         "UUID",
+	SKU:          "SKU",
+	Family:       "Family",
+}
+var baseboard = SMTableBaseboard{
+	Manufacturer: "Manufacturer",
+	Product:      "Product",
+	Version:      "Version",
+	Serial:       "Serial",
+	Asset:        "Asset",
+	Location:     "Location",
+}
+var chassis = SMTableChassis{
+	Manufacturer: "Manufacturer",
+	Version:      "Version",
+	Serial:       "Serial",
+	Asset:        "Asset",
+	SKU:          "SKU",
+}
+var processor = SMTableProcessor{
+	SocketPrefix: "SocketPrefix",
+	Manufacturer: "Manufacturer",
+	Version:      "Version",
+	Serial:       "Serial",
+	Asset:        "Asset",
+	Part:         "Part",
+}
+var memory = SMTableMemory{
+	LocationPrefix: "LocationPrefix",
+	Bank:           "Bank",
+	Manufacturer:   "Manufacturer",
+	Serial:         "Serial",
+	Asset:          "Asset",
+	Part:           "Part",
+	Speed:          "3600",
+}
+var smbFull = SMBIOSInfo{
+	BIOS:       bios,
+	System:     system,
+	Baseboard:  baseboard,
+	Chassis:    chassis,
+	Processors: []SMTableProcessor{processor},
+	Memory:     []SMTableMemory{memory},
+}
+
+func TestAppendSMBIOSFile(t *testing.T) {
+	smb := SMBIOSInfo{
+		File: "foo",
+	}
+	testAppend(smb, smbFile, t)
+}
+
+func TestAppendSMBIOSType0BIOS(t *testing.T) {
+	smb := SMBIOSInfo{
+		BIOS: bios,
+	}
+	testAppend(smb, smbType0Bios, t)
+}
+
+func TestAppendSMBIOSType1System(t *testing.T) {
+	smb := SMBIOSInfo{
+		System: system,
+	}
+	testAppend(smb, smbType1System, t)
+}
+
+func TestAppendSMBIOSType2Baseboard(t *testing.T) {
+	smb := SMBIOSInfo{
+		Baseboard: baseboard,
+	}
+	testAppend(smb, smbType2Baseboard, t)
+}
+
+func TestAppendSMBIOSType3Chassis(t *testing.T) {
+	smb := SMBIOSInfo{
+		Chassis: chassis,
+	}
+	testAppend(smb, smbType3Chassis, t)
+}
+
+func TestAppendSMBIOSType4Processor(t *testing.T) {
+	smb := SMBIOSInfo{
+		Processors: []SMTableProcessor{processor},
+	}
+	testAppend(smb, smbType4Processor, t)
+}
+
+func TestAppendSMBIOSType17Memory(t *testing.T) {
+	smb := SMBIOSInfo{
+		Memory: []SMTableMemory{memory},
+	}
+	testAppend(smb, smbType17Memory, t)
+}
+
+func TestAppendSMBIOSFUll(t *testing.T) {
+	tables := []string{smbType0Bios, smbType1System, smbType2Baseboard, smbType3Chassis, smbType4Processor, smbType17Memory}
+	smbFullStr := strings.Join(tables, " ")
+	testAppend(smbFull, smbFullStr, t)
+}


### PR DESCRIPTION
- Implement -smbios file|type{0,1,2,3,4,17}
- Fix qemu_test testConfigAppend, missing TPMDevice, added SMBIOSInfo

YAML looks like:

```yaml
smbios:
  file:
  bios:
    vendor:
    version:
    date:
    release:
    uefi:
  system:
    manufacturer:
    product:
    version:
    serial:
    uuid:
    sku:
    family:
  baseboard:
    manufacturer:
    product:
    version:
    serial:
    asset:
    location:
  chassis:
    manufacturer:
    version:
    serial:
    asset:
    sku:
  processors:
    - socket-prefix:
      manufacturer:
      version:
      serial:
      asset:
      part:
  memory:
    - location-prefix:
      bank:
      manufacturer:
      version:
      serial:
      asset:
      part:
      speed:
```
