### PR TITLE
netdevice: Allow multiple hostfwd rules per User netdevice

### DIFF
--- a/netdevice.go
+++ b/netdevice.go
@@ -234,9 +234,9 @@ const EmptyPortRule = "::0-:0"
 
 // -netdev user,
 type NetDeviceUser struct {
-	IPV4        bool     `yaml:"ipv4-enable"`
-	IPV4NetAddr string   `yaml:"ipv4-network-address"`
-	HostForward PortRule `yaml:"host-port-rule"`
+	IPV4        bool       `yaml:"ipv4-enable"`
+	IPV4NetAddr string     `yaml:"ipv4-network-address"`
+	HostForward []PortRule `yaml:"host-port-rules"`
 }
 
 // -netdev socket,listen=
@@ -471,9 +471,11 @@ func (netdev NetDevice) QemuNetdevParams(config *Config) []string {
 			netdevParams = append(netdevParams, "ipv4=off")
 		}
 
-		hostfwd := netdev.User.HostForward.String()
-		if hostfwd != EmptyPortRule {
-			netdevParams = append(netdevParams, fmt.Sprintf("hostfwd=%s", hostfwd))
+		for _, rule := range netdev.User.HostForward {
+			hostfwd := rule.String()
+			if hostfwd != EmptyPortRule {
+				netdevParams = append(netdevParams, fmt.Sprintf("hostfwd=%s", hostfwd))
+			}
 		}
 
 		if netdev.User.IPV4NetAddr != "" {

--- a/netdevice_test.go
+++ b/netdevice_test.go
@@ -12,7 +12,7 @@ var (
 	deviceNetworkPCIStringMq       = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=0xff,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,romfile=efi-virtio.rom"
 	deviceNetworkUserString        = "-netdev user,id=user0,ipv4=on,net=10.0.2.15/24 -device e1000,netdev=user0,mac=01:02:de:ad:be:ef"
-	deviceNetworkUserHostFwdString = "-netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,disable-modern=false"
+	deviceNetworkUserHostFwdString = "-netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22,hostfwd=tcp::8080-:80 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,disable-modern=false"
 	deviceNetworkMcastSocketString = "-netdev socket,id=sock0,mcast=230.0.0.1:1234 -device virtio-net-pci,netdev=sock0,mac=01:02:de:ad:be:ef,disable-modern=true"
 	deviceNetworkTapMqString       = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
 )
@@ -64,10 +64,17 @@ func TestAppendDeviceNetworkUserHostForward(t *testing.T) {
 		MACAddress:    "01:02:de:ad:be:ef",
 		User: NetDeviceUser{
 			IPV4: true,
-			HostForward: PortRule{
-				Protocol: "tcp",
-				Host:     Port{Port: 22222},
-				Guest:    Port{Port: 22},
+			HostForward: []PortRule{
+				PortRule{
+					Protocol: "tcp",
+					Host:     Port{Port: 22222},
+					Guest:    Port{Port: 22},
+				},
+				PortRule{
+					Protocol: "tcp",
+					Host:     Port{Port: 8080},
+					Guest:    Port{Port: 80},
+				},
 			},
 		},
 	}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -754,10 +754,12 @@ func fullVMConfig() *Config {
 				Bus:        "pcie.0",
 				User: NetDeviceUser{
 					IPV4: true,
-					HostForward: PortRule{
-						Protocol: "tcp",
-						Host:     Port{Port: 22222},
-						Guest:    Port{Port: 22},
+					HostForward: []PortRule{
+						PortRule{
+							Protocol: "tcp",
+							Host:     Port{Port: 22222},
+							Guest:    Port{Port: 22},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
The 'hostfwd' option to 'user' net device can be repeated multiple times to forward more than one port range.