### PR TITLE
netdevice: disable netdevice use of romfile option

### DIFF
--- a/netdevice.go
+++ b/netdevice.go
@@ -60,6 +60,8 @@ const (
 
 	// VHOSTUSER is a vhost-user port (socket)
 	VHOSTUSER NetDeviceType = "vhostuser"
+
+	DisabledNetDeviceROMFile = "off"
 )
 
 // QemuNetdevParam converts to the QEMU -netdev parameter notation
@@ -406,7 +408,12 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 	}
 
 	if netdev.Transport.isVirtioPCI(config) && netdev.ROMFile != "" {
-		deviceParams = append(deviceParams, fmt.Sprintf("romfile=%s", netdev.ROMFile))
+		// allow setting romfile= to disable the built-in romfile for the nic
+		romfile := netdev.ROMFile
+		if romfile == DisabledNetDeviceROMFile {
+			romfile = ""
+		}
+		deviceParams = append(deviceParams, fmt.Sprintf("romfile=%s", romfile))
 	}
 
 	if netdev.Transport.isVirtioCCW(config) {

--- a/netdevice_test.go
+++ b/netdevice_test.go
@@ -11,7 +11,7 @@ var (
 	deviceNetworkPCIStringLowAddr  = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=0x03,disable-modern=true,romfile=efi-virtio.rom"
 	deviceNetworkPCIStringMq       = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=0xff,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,romfile=efi-virtio.rom"
-	deviceNetworkUserString        = "-netdev user,id=user0,ipv4=on,net=10.0.2.15/24 -device e1000,netdev=user0,mac=01:02:de:ad:be:ef"
+	deviceNetworkUserString        = "-netdev user,id=user0,ipv4=on,net=10.0.2.15/24 -device e1000,netdev=user0,mac=01:02:de:ad:be:ef,romfile="
 	deviceNetworkUserHostFwdString = "-netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22,hostfwd=tcp::8080-:80 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,disable-modern=false"
 	deviceNetworkMcastSocketString = "-netdev socket,id=sock0,mcast=230.0.0.1:1234 -device virtio-net-pci,netdev=sock0,mac=01:02:de:ad:be:ef,disable-modern=true"
 	deviceNetworkTapMqString       = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
@@ -46,6 +46,7 @@ func TestAppendDeviceNetworkUser(t *testing.T) {
 		Type:       USER,
 		ID:         "user0",
 		MACAddress: "01:02:de:ad:be:ef",
+		ROMFile:    DisabledNetDeviceROMFile,
 		User: NetDeviceUser{
 			IPV4:        true,
 			IPV4NetAddr: "10.0.2.15/24",


### PR DESCRIPTION
Some cases, VMs want a nic but do not want it to be used during boot (no PXE) which can be acheived by passing 'romfile=' (no value set) This prevents the built-in romfile from being loaded and the nic will not be presented to the BIOS as a bootable device.

NetDevice.ROMFile = DisabledNetDeviceROMFile

will emit the 'romfile=' in the command line preventing nic from being used during BIOS boot.