### PR TITLE
pci-serial additions

### DIFF
--- a/chardevice.go
+++ b/chardevice.go
@@ -179,8 +179,6 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	if cdev.Driver == PCISerial {
 		qemuParams = append(qemuParams, "-serial")
 		qemuParams = append(qemuParams, "none")
-		qemuParams = append(qemuParams, "-monitor")
-		qemuParams = append(qemuParams, "none")
 	}
 
 	qemuParams = append(qemuParams, "-chardev")

--- a/chardevice.go
+++ b/chardevice.go
@@ -170,9 +170,17 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	}
 
 	// Legacy serial is special. It does not follow the device + driver model
-	if cdev.Driver != LegacySerial {
+	if cdev.Driver != LegacySerial && cdev.Driver != PCISerial {
 		qemuParams = append(qemuParams, "-device")
 		qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
+	}
+	
+	//appending -serial none and -monitor none to qemuparams if we are using pci-serial
+	if cdev.Driver == PCISerial {
+		qemuParams = append(qemuParams, "-serial")
+		qemuParams = append(qemuParams, "none")
+		qemuParams = append(qemuParams, "-monitor")
+		qemuParams = append(qemuParams, "none")
 	}
 
 	qemuParams = append(qemuParams, "-chardev")

--- a/chardevice.go
+++ b/chardevice.go
@@ -170,13 +170,13 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	}
 
 	// Legacy serial is special. It does not follow the device + driver model
-	if cdev.Driver != LegacySerial && cdev.Driver != PCISerial {
+	if cdev.Driver != LegacySerial && cdev.Driver != PCISerialDevice {
 		qemuParams = append(qemuParams, "-device")
 		qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
 	}
-	
+
 	//appending -serial none and -monitor none to qemuparams if we are using pci-serial
-	if cdev.Driver == PCISerial {
+	if cdev.Driver == PCISerialDevice {
 		qemuParams = append(qemuParams, "-serial")
 		qemuParams = append(qemuParams, "none")
 	}

--- a/chardevice_test.go
+++ b/chardevice_test.go
@@ -8,6 +8,7 @@ var (
 	deviceCharDeviceBackendStdioMux = "-chardev stdio,id=serial0,mux=on,signal=off"
 	deviceCharDeviceMultiple        = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off"
 	deviceCharDevicePCIDriver		= "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,id=pciser0,chardev=serial0"
+	deviceCharDevicePCIDriver2x		= "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial-2x,id=pciser0,chardev1=serial0"
 )
 
 func TestBadCharDevice(t *testing.T) {
@@ -81,7 +82,7 @@ func TestAppendMultipleCharDevices(t *testing.T) {
 	testConfig(c, deviceCharDeviceMultiple, t)
 }
 
-func TestAppendPCIDriver(t *testing.T) {
+func TestAppendPCIDriver1x(t *testing.T) {
 	c := &Config{}
 	serial := CharDevice {
 		Driver: PCISerial,
@@ -92,9 +93,29 @@ func TestAppendPCIDriver(t *testing.T) {
 	pcidev := SerialDevice {
 		Driver:        PCISerial,
 		ID: 		   "pciser0",
-		ChardevID:	   "serial0",
+		ChardevIDs:	   []string{"serial0"},
+		MaxPorts: 		1,
 	}
 	c.CharDevices = []CharDevice{serial}
 	c.SerialDevices = []SerialDevice{pcidev}
 	testConfig(c, deviceCharDevicePCIDriver, t)
+}
+
+func TestAppendPCIDriver2x1(t *testing.T) {
+	c := &Config{}
+	serial := CharDevice {
+		Driver: PCISerial,
+		Backend: Socket,
+		ID: "serial0",
+		Path: "/tmp/console.sock",
+	}
+	pcidev := SerialDevice {
+		Driver:        PCISerial,
+		ID: 		   "pciser0",
+		ChardevIDs:	   []string{"serial0"},
+		MaxPorts: 		2,
+	}
+	c.CharDevices = []CharDevice{serial}
+	c.SerialDevices = []SerialDevice{pcidev}
+	testConfig(c, deviceCharDevicePCIDriver2x, t)
 }

--- a/chardevice_test.go
+++ b/chardevice_test.go
@@ -7,6 +7,7 @@ var (
 	deviceCharDeviceBackendSocket   = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off"
 	deviceCharDeviceBackendStdioMux = "-chardev stdio,id=serial0,mux=on,signal=off"
 	deviceCharDeviceMultiple        = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off"
+	deviceCharDevicePCIDriver		= "-serial none -monitor none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,chardev=serial0"
 )
 
 func TestBadCharDevice(t *testing.T) {
@@ -78,4 +79,20 @@ func TestAppendMultipleCharDevices(t *testing.T) {
 	}
 	c.CharDevices = []CharDevice{serial, mon}
 	testConfig(c, deviceCharDeviceMultiple, t)
+}
+
+func TestAppendPCIDriver(t *testing.T) {
+	c := &Config{}
+	serial := CharDevice {
+		Driver: PCISerial,
+		Backend: Socket,
+		ID: "serial0",
+		Path: "/tmp/console.sock",
+	}
+	pcidev := PCISerialDevice {
+		ChardevID: "serial0",
+	}
+	c.CharDevices = []CharDevice{serial}
+	c.PCISerialDevices = []PCISerialDevice{pcidev}
+	testConfig(c, deviceCharDevicePCIDriver, t)
 }

--- a/chardevice_test.go
+++ b/chardevice_test.go
@@ -7,8 +7,8 @@ var (
 	deviceCharDeviceBackendSocket   = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off"
 	deviceCharDeviceBackendStdioMux = "-chardev stdio,id=serial0,mux=on,signal=off"
 	deviceCharDeviceMultiple        = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off"
-	deviceCharDevicePCIDriver		= "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,id=pciser0,chardev=serial0"
-	deviceCharDevicePCIDriver2x		= "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial-2x,id=pciser0,chardev1=serial0"
+	deviceCharDevicePCIDriver       = "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,id=pciser0,chardev=serial0"
+	deviceCharDevicePCIDriver2x     = "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial-2x,id=pciser0,chardev1=serial0"
 )
 
 func TestBadCharDevice(t *testing.T) {
@@ -84,17 +84,17 @@ func TestAppendMultipleCharDevices(t *testing.T) {
 
 func TestAppendPCIDriver1x(t *testing.T) {
 	c := &Config{}
-	serial := CharDevice {
-		Driver: PCISerial,
+	serial := CharDevice{
+		Driver:  PCISerialDevice,
 		Backend: Socket,
-		ID: "serial0",
-		Path: "/tmp/console.sock",
+		ID:      "serial0",
+		Path:    "/tmp/console.sock",
 	}
-	pcidev := SerialDevice {
-		Driver:        PCISerial,
-		ID: 		   "pciser0",
-		ChardevIDs:	   []string{"serial0"},
-		MaxPorts: 		1,
+	pcidev := SerialDevice{
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0"},
+		MaxPorts:   1,
 	}
 	c.CharDevices = []CharDevice{serial}
 	c.SerialDevices = []SerialDevice{pcidev}
@@ -103,17 +103,17 @@ func TestAppendPCIDriver1x(t *testing.T) {
 
 func TestAppendPCIDriver2x1(t *testing.T) {
 	c := &Config{}
-	serial := CharDevice {
-		Driver: PCISerial,
+	serial := CharDevice{
+		Driver:  PCISerialDevice,
 		Backend: Socket,
-		ID: "serial0",
-		Path: "/tmp/console.sock",
+		ID:      "serial0",
+		Path:    "/tmp/console.sock",
 	}
-	pcidev := SerialDevice {
-		Driver:        PCISerial,
-		ID: 		   "pciser0",
-		ChardevIDs:	   []string{"serial0"},
-		MaxPorts: 		2,
+	pcidev := SerialDevice{
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0"},
+		MaxPorts:   2,
 	}
 	c.CharDevices = []CharDevice{serial}
 	c.SerialDevices = []SerialDevice{pcidev}

--- a/chardevice_test.go
+++ b/chardevice_test.go
@@ -7,7 +7,7 @@ var (
 	deviceCharDeviceBackendSocket   = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off"
 	deviceCharDeviceBackendStdioMux = "-chardev stdio,id=serial0,mux=on,signal=off"
 	deviceCharDeviceMultiple        = "-chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off"
-	deviceCharDevicePCIDriver		= "-serial none -monitor none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,chardev=serial0"
+	deviceCharDevicePCIDriver		= "-serial none -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -device pci-serial,id=pciser0,chardev=serial0"
 )
 
 func TestBadCharDevice(t *testing.T) {
@@ -89,10 +89,12 @@ func TestAppendPCIDriver(t *testing.T) {
 		ID: "serial0",
 		Path: "/tmp/console.sock",
 	}
-	pcidev := PCISerialDevice {
-		ChardevID: "serial0",
+	pcidev := SerialDevice {
+		Driver:        PCISerial,
+		ID: 		   "pciser0",
+		ChardevID:	   "serial0",
 	}
 	c.CharDevices = []CharDevice{serial}
-	c.PCISerialDevices = []PCISerialDevice{pcidev}
+	c.SerialDevices = []SerialDevice{pcidev}
 	testConfig(c, deviceCharDevicePCIDriver, t)
 }

--- a/device.go
+++ b/device.go
@@ -238,10 +238,6 @@ func (config *Config) appendDevices() error {
 			for _, d := range config.UEFIFirmwareDevices {
 				config.devices = append(config.devices, d)
 			}
-		case "PCISerialDevices":
-			for _, d := range config.PCISerialDevices {
-				config.devices = append(config.devices, d)
-			}
 		}
 	}
 

--- a/device.go
+++ b/device.go
@@ -168,7 +168,7 @@ const (
 	TPMCRBDebice DeviceDriver = "tpm-crb"
 
 	// PCI Serial Device
-	PCISerial DeviceDriver = "pci-serial"
+	PCISerialDevice DeviceDriver = "pci-serial"
 )
 
 func (config *Config) appendDevices() error {

--- a/device.go
+++ b/device.go
@@ -167,7 +167,7 @@ const (
 	// TPM-CRB TPM Device
 	TPMCRBDebice DeviceDriver = "tpm-crb"
 
-	//PCI Serial Device
+	// PCI Serial Device
 	PCISerial DeviceDriver = "pci-serial"
 )
 

--- a/device.go
+++ b/device.go
@@ -166,6 +166,9 @@ const (
 
 	// TPM-CRB TPM Device
 	TPMCRBDebice DeviceDriver = "tpm-crb"
+
+	//PCI Serial Device
+	PCISerial DeviceDriver = "pci-serial"
 )
 
 func (config *Config) appendDevices() error {
@@ -233,6 +236,10 @@ func (config *Config) appendDevices() error {
 			}
 		case "UEFIFirmwareDevices":
 			for _, d := range config.UEFIFirmwareDevices {
+				config.devices = append(config.devices, d)
+			}
+		case "PCISerialDevices":
+			for _, d := range config.PCISerialDevices {
 				config.devices = append(config.devices, d)
 			}
 		}

--- a/qemu.go
+++ b/qemu.go
@@ -243,7 +243,6 @@ type Config struct {
 	CharDevices           []CharDevice           `yaml:"char-devices"`
 	LegacySerialDevices   []LegacySerialDevice   `yaml:"legacy-serial-devices"`
 	SerialDevices         []SerialDevice         `yaml:"serial-devices"`
-	PCISerialDevices 	  []PCISerialDevice	     `yaml:"pci-serial-devices"`
 	MonitorDevices        []MonitorDevice        `yaml:"monitor-devices"`
 	PCIeRootPortDevices   []PCIeRootPortDevice   `yaml:"pcie-root-port-devices"`
 	UEFIFirmwareDevices   []UEFIFirmwareDevice   `yaml:"uefi-firmware-devices"`

--- a/qemu.go
+++ b/qemu.go
@@ -243,6 +243,7 @@ type Config struct {
 	CharDevices           []CharDevice           `yaml:"char-devices"`
 	LegacySerialDevices   []LegacySerialDevice   `yaml:"legacy-serial-devices"`
 	SerialDevices         []SerialDevice         `yaml:"serial-devices"`
+	PCISerialDevices 	  []PCISerialDevice	     `yaml:"pci-serial-devices"`
 	MonitorDevices        []MonitorDevice        `yaml:"monitor-devices"`
 	PCIeRootPortDevices   []PCIeRootPortDevice   `yaml:"pcie-root-port-devices"`
 	UEFIFirmwareDevices   []UEFIFirmwareDevice   `yaml:"uefi-firmware-devices"`

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -19,10 +19,10 @@ package qcli
 import (
 	"os"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
-	"runtime"
 )
 
 const agentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
@@ -700,11 +700,11 @@ func TestBadCPUs(t *testing.T) {
 }
 
 var (
-	fullUefiVM      = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
-	fullBiosVM      = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
-	fullUefiVMSpice = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -spice port=5901,addr=127.0.0.1 -device virtio-serial-pci -device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
-	fullUefiVMTPM   = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -chardev socket,id=chrtpm0,path=tpm.socket -tpmdev emulator,id=tpm0,chardev=chrtpm0 -device tpm-tis,tpmdev=tpm0 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
-	fullUefiAarch64VM = "-machine virt,accel=kvm -cpu host -m 1G -drive file=udisk.img,id=hd0,if=none,format=qcow2 -device virtio-blk-pci,drive=hd0,serial=hd0,disable-modern=false,addr=0x1e,bus=pcie.0,scsi=off,config-wce=off -drive file=ubuntu-22.04.2-live-server-arm64.iso,id=cdrom0,if=none,format=raw,media=cdrom,readonly=on -device virtio-blk-pci,drive=cdrom0,serial=cdrom0,bootindex=0,disable-modern=false,addr=0x1d,bus=pcie.0,scsi=off,config-wce=off -drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.ms.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -object memory-backend-ram,id=dimm1,size=1G -numa node,memdev=dimm1 -nographic"
+	fullUefiVM           = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
+	fullBiosVM           = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
+	fullUefiVMSpice      = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -spice port=5901,addr=127.0.0.1 -device virtio-serial-pci -device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
+	fullUefiVMTPM        = "-machine q35,accel=kvm,smm=on -cpu qemu64,+x2apic -m 4096 -chardev socket,id=chrtpm0,path=tpm.socket -tpmdev emulator,id=tpm0,chardev=chrtpm0 -device tpm-tis,tpmdev=tpm0 -device pcie-root-port,id=root-port.0x4.0,bus=pcie.0,chassis=0x0,slot=0x00,port=0x0,addr=0x5,multifunction=on -device pcie-root-port,id=root-port.0x4.1,bus=pcie.0,chassis=0x1,slot=0x00,port=0x1,addr=0x5.0x1 -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0,bus=pcie.0,addr=0x03 -drive file=boot.qcow2,id=drive0,if=none,format=qcow2,aio=threads,cache=unsafe,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=drive0,serial=ssd-boot,bootindex=0,disable-modern=true,addr=0x04,bus=pcie.0,logical_block_size=512,physical_block_size=512,scsi=off,config-wce=off -netdev user,id=user0,ipv4=on,hostfwd=tcp::22222-:22 -device virtio-net-pci,netdev=user0,mac=01:02:de:ad:be:ef,bus=pcie.0,disable-modern=false -chardev socket,id=serial0,path=/tmp/console.sock,server=on,wait=off -chardev socket,id=monitor0,path=/tmp/monitor.sock,server=on,wait=off -serial chardev:serial0 -monitor chardev:monitor0 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -global ICH9-LPC.disable_s3=1 -global driver=cfi.pflash01,property=secure,value=on -object memory-backend-file,id=dimm1,size=4096,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1 -nographic -no-hpet -snapshot -smp 4"
+	fullUefiAarch64VM    = "-machine virt,accel=kvm -cpu host -m 1G -drive file=udisk.img,id=hd0,if=none,format=qcow2 -device virtio-blk-pci,drive=hd0,serial=hd0,disable-modern=false,addr=0x1e,bus=pcie.0,scsi=off,config-wce=off -drive file=ubuntu-22.04.2-live-server-arm64.iso,id=cdrom0,if=none,format=raw,media=cdrom,readonly=on -device virtio-blk-pci,drive=cdrom0,serial=cdrom0,bootindex=0,disable-modern=false,addr=0x1d,bus=pcie.0,scsi=off,config-wce=off -drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.ms.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -object memory-backend-ram,id=dimm1,size=1G -numa node,memdev=dimm1 -nographic"
 	fullUefiAarch64VMTPM = "-machine virt,accel=kvm -cpu host -m 1G -chardev socket,id=chrtpm0,path=tpm.socket -tpmdev emulator,id=tpm0,chardev=chrtpm0 -device tpm-tis-device,tpmdev=tpm0 -drive file=udisk.img,id=hd0,if=none,format=qcow2 -device virtio-blk-pci,drive=hd0,serial=hd0,disable-modern=false,addr=0x1e,bus=pcie.0,scsi=off,config-wce=off -drive file=ubuntu-22.04.2-live-server-arm64.iso,id=cdrom0,if=none,format=raw,media=cdrom,readonly=on -device virtio-blk-pci,drive=cdrom0,serial=cdrom0,bootindex=0,disable-modern=false,addr=0x1d,bus=pcie.0,scsi=off,config-wce=off -drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.ms.fd -drive if=pflash,format=raw,file=uefi_nvram.fd -object memory-backend-ram,id=dimm1,size=1G -numa node,memdev=dimm1 -nographic"
 )
 
@@ -837,26 +837,26 @@ func fullVMConfigAarch64() *Config {
 			Type:         MachineTypeVirt,
 			Acceleration: MachineAccelerationKVM,
 		},
-		CPUModel:      "host",
+		CPUModel: "host",
 		Memory: Memory{
 			Size: "1G",
 		},
 		BlkDevices: []BlockDevice{
 			BlockDevice{
-				Driver: VirtioBlock,
-				ID: "hd0",
-				File: "udisk.img",
-				Format:	QCOW2,
+				Driver:    VirtioBlock,
+				ID:        "hd0",
+				File:      "udisk.img",
+				Format:    QCOW2,
 				Interface: NoInterface,
 			},
-			BlockDevice {
-				Driver: VirtioBlock,
+			BlockDevice{
+				Driver:    VirtioBlock,
 				Interface: NoInterface,
-				ID: "cdrom0",
-				File: "ubuntu-22.04.2-live-server-arm64.iso",
-				Format: RAW,
-				ReadOnly: true,
-				Media: "cdrom",
+				ID:        "cdrom0",
+				File:      "ubuntu-22.04.2-live-server-arm64.iso",
+				Format:    RAW,
+				ReadOnly:  true,
+				Media:     "cdrom",
 				BootIndex: "0",
 			},
 		},
@@ -867,10 +867,9 @@ func fullVMConfigAarch64() *Config {
 	return c
 }
 
-
 func TestFullUEFIMachineCommand(t *testing.T) {
 	var c *Config
-	u := UEFIFirmwareDevice{Code: "", Vars: "uefi_nvram.fd",}
+	u := UEFIFirmwareDevice{Code: "", Vars: "uefi_nvram.fd"}
 	expected := ""
 	switch runtime.GOARCH {
 	case "aarch64", "arm64":
@@ -919,7 +918,7 @@ func TestFullUEFISpiceMachineCommand(t *testing.T) {
 
 func TestFullUEFITPMMachineCommand(t *testing.T) {
 	var c *Config
-	u := UEFIFirmwareDevice{Code: "", Vars: "uefi_nvram.fd",}
+	u := UEFIFirmwareDevice{Code: "", Vars: "uefi_nvram.fd"}
 	expected := ""
 	switch runtime.GOARCH {
 	case "aarch64", "arm64":
@@ -931,7 +930,7 @@ func TestFullUEFITPMMachineCommand(t *testing.T) {
 		u.Code = "/usr/share/OVMF/OVMF_CODE.fd"
 		expected = fullUefiVMTPM
 	}
-	
+
 	c.UEFIFirmwareDevices = append(c.UEFIFirmwareDevices, u)
 
 	c.TPM = TPMDevice{

--- a/serialdevice.go
+++ b/serialdevice.go
@@ -130,7 +130,7 @@ type SerialDevice struct {
 	Transport VirtioTransport
 
 	//pci-serial specific attributes
-	//Chardev associated with PCISerial
+	//Chardev associated with PCISerialDevice
 	ChardevIDs []string
 
 	Multifunction bool
@@ -144,19 +144,19 @@ func (dev SerialDevice) Valid() error {
 	if dev.ID == "" {
 		return fmt.Errorf("SerialDevice has empty ID field")
 	}
-	if (dev.Driver == PCISerial) {
-		if (len(dev.ChardevIDs) > 4 || len(dev.ChardevIDs) == 0) {
-			return fmt.Errorf("PCISerialDevice has a malformed list of ChardevIDs (length 0 or length > 4)")
-		} 
+	if dev.Driver == PCISerialDevice {
+		if len(dev.ChardevIDs) > 4 || len(dev.ChardevIDs) == 0 {
+			return fmt.Errorf("PCISerialDeviceDevice has a malformed list of ChardevIDs (length 0 or length > 4)")
+		}
 		if dev.ChardevIDs[0] == "" {
-			return fmt.Errorf("PCISerialDevice has no associated ChardevID")
+			return fmt.Errorf("PCISerialDeviceDevice has no associated ChardevID")
 		}
 		if dev.MaxPorts != 1 && dev.MaxPorts != 2 && dev.MaxPorts != 4 {
-			return fmt.Errorf("PCISerialDevice has Ports not equal to 1, 2, or 4")
+			return fmt.Errorf("PCISerialDeviceDevice has MaxPorts not equal to 1, 2, or 4")
 		}
-		
+
 	}
-	
+
 	return nil
 }
 
@@ -171,7 +171,7 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf("addr=%s", dev.Addr))
 	}
 	if dev.ROMFile != "" {
-		if dev.Driver == PCISerial || dev.Transport.isVirtioPCI(config) {
+		if dev.Driver == PCISerialDevice || dev.Transport.isVirtioPCI(config) {
 			deviceParams = append(deviceParams, fmt.Sprintf("romfile=%s", dev.ROMFile))
 		}
 	}
@@ -192,7 +192,7 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 			}
 			deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", dev.DevNo))
 		}
-	case PCISerial:
+	case PCISerialDevice:
 		if dev.MaxPorts == 1 {
 			deviceParams = append(deviceParams, fmt.Sprintf("chardev=%s", dev.ChardevIDs[0]))
 		} else {
@@ -227,7 +227,7 @@ func (dev SerialDevice) deviceName(config *Config) string {
 		}
 		devNameStr = VirtioSerialTransport[dev.Transport]
 	}
-	if dev.Driver == PCISerial {
+	if dev.Driver == PCISerialDevice {
 		add_str := ""
 		if dev.MaxPorts == 2 {
 			add_str = "-2x"

--- a/serialdevice.go
+++ b/serialdevice.go
@@ -119,6 +119,9 @@ type SerialDevice struct {
 	// MaxPorts is the maximum number of ports for this device. (note: 1, 2, or 4 for pci-serial driver)
 	MaxPorts uint
 
+	//Enable Multifunction
+	Multifunction bool
+
 	//virtio-serial specific attributes
 	// DisableModern prevents qemu from relying on fast MMIO.
 	DisableModern bool
@@ -132,8 +135,6 @@ type SerialDevice struct {
 	//pci-serial specific attributes
 	//Chardev associated with PCISerialDevice
 	ChardevIDs []string
-
-	Multifunction bool
 }
 
 // Valid returns true if the SerialDevice structure is valid and complete.

--- a/serialdevice.go
+++ b/serialdevice.go
@@ -182,3 +182,29 @@ func (dev SerialDevice) deviceName(config *Config) string {
 
 	return string(dev.Driver)
 }
+
+type PCISerialDevice struct {
+	// specify a chardev-id of an existing CharDev, and use the name
+	ChardevID string `yaml:"chardev-id"`
+}
+
+func (pDev PCISerialDevice) Valid() error {
+	if pDev.ChardevID == "" {
+		return fmt.Errorf("PCISerialDevice has empty ChardevID field")
+	}
+	return nil
+}
+
+func (pDev PCISerialDevice) QemuParams(conifg *Config) []string {
+	var deviceParams []string
+	var qemuParams []string
+
+	
+	deviceParams = append(deviceParams, "pci-serial")
+	deviceParams = append(deviceParams, fmt.Sprintf("chardev=%s", pDev.ChardevID))
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
+
+	return qemuParams
+}

--- a/serialdevice.go
+++ b/serialdevice.go
@@ -145,13 +145,18 @@ func (dev SerialDevice) Valid() error {
 		return fmt.Errorf("SerialDevice has empty ID field")
 	}
 	if (dev.Driver == PCISerial) {
+		if (len(dev.ChardevIDs) > 4 || len(dev.ChardevIDs) == 0) {
+			return fmt.Errorf("PCISerialDevice has a malformed list of ChardevIDs (length 0 or length > 4)")
+		} 
 		if dev.ChardevIDs[0] == "" {
 			return fmt.Errorf("PCISerialDevice has no associated ChardevID")
 		}
 		if dev.MaxPorts != 1 && dev.MaxPorts != 2 && dev.MaxPorts != 4 {
 			return fmt.Errorf("PCISerialDevice has Ports not equal to 1, 2, or 4")
 		}
-	} 
+		
+	}
+	
 	return nil
 }
 

--- a/serialdevice_test.go
+++ b/serialdevice_test.go
@@ -144,3 +144,28 @@ func TestAppendDevicePCISerial4x4Char(t *testing.T) {
 	}
 	testAppend(sdev, devicePCISerialString4x4, t)
 }
+
+func TestAppendMalformedPCISerialChardevIDs(t *testing.T) {
+	device := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		MaxPorts:		2,
+	}
+
+	if err := device.Valid(); err == nil {
+		t.Fatalf("SerialDevice should not have empty ChardevIDs list")
+	}
+}
+
+func TestAppendLongPCISerialChardevIDs(t *testing.T) {
+	device := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevIDs:    []string{"serial0", "serial1", "serial2", "serial3", "serial4"},
+		MaxPorts:	    2,
+	}
+
+	if err := device.Valid(); err == nil {
+		t.Fatalf("SerialDevice should not have ChardevIDs list of length > 4")
+	}
+}

--- a/serialdevice_test.go
+++ b/serialdevice_test.go
@@ -9,6 +9,7 @@ var (
 	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom,max_ports=2"
 	deviceVirtioSerialPortString   = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server=on,wait=off"
 	deviceSpiceSerialPortString    = "-device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent"
+	devicePCISerialString		   = "-device pci-serial,chardev=serial0"
 )
 
 func TestAppendLegacySerialMonMux(t *testing.T) {
@@ -87,4 +88,12 @@ func TestAppendEmptySerialDevice(t *testing.T) {
 	if err := device.Valid(); err == nil {
 		t.Fatalf("SerialDevice should not be valid when ID is empty")
 	}
+}
+
+func TestAppendPCISerialDevice(t *testing.T) {
+	sdev := PCISerialDevice{
+		ChardevID: "serial0",
+	}
+
+	testAppend(sdev, devicePCISerialString, t)
 }

--- a/serialdevice_test.go
+++ b/serialdevice_test.go
@@ -10,6 +10,10 @@ var (
 	deviceVirtioSerialPortString   = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server=on,wait=off"
 	deviceSpiceSerialPortString    = "-device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent"
 	devicePCISerialString		   = "-device pci-serial,id=pciser0,chardev=serial0"
+	devicePCISerialString2x1	   = "-device pci-serial-2x,id=pciser0,chardev1=serial0"
+	devicePCISerialString2x2	   = "-device pci-serial-2x,id=pciser0,chardev1=serial0,chardev2=serial1"
+	devicePCISerialString4x2	   = "-device pci-serial-4x,id=pciser0,chardev1=serial0,chardev2=serial1"
+	devicePCISerialString4x4	   = "-device pci-serial-4x,id=pciser0,multifunction=on,chardev1=serial0,chardev2=serial1,chardev3=serial2,chardev4=serial3"
 )
 
 func TestAppendLegacySerialMonMux(t *testing.T) {
@@ -94,7 +98,49 @@ func TestAppendDevicePCISerial(t *testing.T) {
 	sdev := SerialDevice{
 		Driver:        PCISerial,
 		ID:            "pciser0",
-		ChardevID:	   "serial0",
+		ChardevIDs:	   []string{"serial0"},
+		MaxPorts:		1,
 	}
 	testAppend(sdev, devicePCISerialString, t)
+}
+
+func TestAppendDevicePCISerial2x1Char(t *testing.T) {
+	sdev := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevIDs:	   []string{"serial0"},
+		MaxPorts:		2,
+	}
+	testAppend(sdev, devicePCISerialString2x1, t)
+}
+
+func TestAppendDevicePCISerial2x2Char(t *testing.T) {
+	sdev := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevIDs:	   []string{"serial0", "serial1"},
+		MaxPorts:		2,
+	}
+	testAppend(sdev, devicePCISerialString2x2, t)
+}
+
+func TestAppendDevicePCISerial4x2Char(t *testing.T) {
+	sdev := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevIDs:	   []string{"serial0", "serial1"},
+		MaxPorts:		4,
+	}
+	testAppend(sdev, devicePCISerialString4x2, t)
+}
+
+func TestAppendDevicePCISerial4x4Char(t *testing.T) {
+	sdev := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevIDs:	   []string{"serial0", "serial1", "serial2", "serial3"},
+		MaxPorts:		4,
+		Multifunction: true,
+	}
+	testAppend(sdev, devicePCISerialString4x4, t)
 }

--- a/serialdevice_test.go
+++ b/serialdevice_test.go
@@ -9,11 +9,11 @@ var (
 	deviceSerialString             = "-device virtio-serial-pci,id=serial0,romfile=efi-virtio.rom,disable-modern=true,max_ports=2"
 	deviceVirtioSerialPortString   = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server=on,wait=off"
 	deviceSpiceSerialPortString    = "-device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent"
-	devicePCISerialString		   = "-device pci-serial,id=pciser0,chardev=serial0"
-	devicePCISerialString2x1	   = "-device pci-serial-2x,id=pciser0,chardev1=serial0"
-	devicePCISerialString2x2	   = "-device pci-serial-2x,id=pciser0,chardev1=serial0,chardev2=serial1"
-	devicePCISerialString4x2	   = "-device pci-serial-4x,id=pciser0,chardev1=serial0,chardev2=serial1"
-	devicePCISerialString4x4	   = "-device pci-serial-4x,id=pciser0,multifunction=on,chardev1=serial0,chardev2=serial1,chardev3=serial2,chardev4=serial3"
+	devicePCISerialDeviceString    = "-device pci-serial,id=pciser0,chardev=serial0"
+	devicePCISerialDeviceString2x1 = "-device pci-serial-2x,id=pciser0,chardev1=serial0"
+	devicePCISerialDeviceString2x2 = "-device pci-serial-2x,id=pciser0,chardev1=serial0,chardev2=serial1"
+	devicePCISerialDeviceString4x2 = "-device pci-serial-4x,id=pciser0,chardev1=serial0,chardev2=serial1"
+	devicePCISerialDeviceString4x4 = "-device pci-serial-4x,id=pciser0,multifunction=on,chardev1=serial0,chardev2=serial1,chardev3=serial2,chardev4=serial3"
 )
 
 func TestAppendLegacySerialMonMux(t *testing.T) {
@@ -94,62 +94,62 @@ func TestAppendEmptySerialDevice(t *testing.T) {
 	}
 }
 
-func TestAppendDevicePCISerial(t *testing.T) {
+func TestAppendDevicePCISerialDevice(t *testing.T) {
 	sdev := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		ChardevIDs:	   []string{"serial0"},
-		MaxPorts:		1,
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0"},
+		MaxPorts:   1,
 	}
-	testAppend(sdev, devicePCISerialString, t)
+	testAppend(sdev, devicePCISerialDeviceString, t)
 }
 
-func TestAppendDevicePCISerial2x1Char(t *testing.T) {
+func TestAppendDevicePCISerialDevice2x1Char(t *testing.T) {
 	sdev := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		ChardevIDs:	   []string{"serial0"},
-		MaxPorts:		2,
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0"},
+		MaxPorts:   2,
 	}
-	testAppend(sdev, devicePCISerialString2x1, t)
+	testAppend(sdev, devicePCISerialDeviceString2x1, t)
 }
 
-func TestAppendDevicePCISerial2x2Char(t *testing.T) {
+func TestAppendDevicePCISerialDevice2x2Char(t *testing.T) {
 	sdev := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		ChardevIDs:	   []string{"serial0", "serial1"},
-		MaxPorts:		2,
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0", "serial1"},
+		MaxPorts:   2,
 	}
-	testAppend(sdev, devicePCISerialString2x2, t)
+	testAppend(sdev, devicePCISerialDeviceString2x2, t)
 }
 
-func TestAppendDevicePCISerial4x2Char(t *testing.T) {
+func TestAppendDevicePCISerialDevice4x2Char(t *testing.T) {
 	sdev := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		ChardevIDs:	   []string{"serial0", "serial1"},
-		MaxPorts:		4,
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0", "serial1"},
+		MaxPorts:   4,
 	}
-	testAppend(sdev, devicePCISerialString4x2, t)
+	testAppend(sdev, devicePCISerialDeviceString4x2, t)
 }
 
-func TestAppendDevicePCISerial4x4Char(t *testing.T) {
+func TestAppendDevicePCISerialDevice4x4Char(t *testing.T) {
 	sdev := SerialDevice{
-		Driver:        PCISerial,
+		Driver:        PCISerialDevice,
 		ID:            "pciser0",
-		ChardevIDs:	   []string{"serial0", "serial1", "serial2", "serial3"},
-		MaxPorts:		4,
+		ChardevIDs:    []string{"serial0", "serial1", "serial2", "serial3"},
+		MaxPorts:      4,
 		Multifunction: true,
 	}
-	testAppend(sdev, devicePCISerialString4x4, t)
+	testAppend(sdev, devicePCISerialDeviceString4x4, t)
 }
 
-func TestAppendMalformedPCISerialChardevIDs(t *testing.T) {
+func TestAppendMalformedPCISerialDeviceChardevIDs(t *testing.T) {
 	device := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		MaxPorts:		2,
+		Driver:   PCISerialDevice,
+		ID:       "pciser0",
+		MaxPorts: 2,
 	}
 
 	if err := device.Valid(); err == nil {
@@ -157,12 +157,12 @@ func TestAppendMalformedPCISerialChardevIDs(t *testing.T) {
 	}
 }
 
-func TestAppendLongPCISerialChardevIDs(t *testing.T) {
+func TestAppendLongPCISerialDeviceChardevIDs(t *testing.T) {
 	device := SerialDevice{
-		Driver:        PCISerial,
-		ID:            "pciser0",
-		ChardevIDs:    []string{"serial0", "serial1", "serial2", "serial3", "serial4"},
-		MaxPorts:	    2,
+		Driver:     PCISerialDevice,
+		ID:         "pciser0",
+		ChardevIDs: []string{"serial0", "serial1", "serial2", "serial3", "serial4"},
+		MaxPorts:   2,
 	}
 
 	if err := device.Valid(); err == nil {

--- a/serialdevice_test.go
+++ b/serialdevice_test.go
@@ -6,10 +6,10 @@ var (
 	deviceLegacySerialMonMuxString = "-serial mon:stdio"
 	deviceLegacySerialString       = "-serial chardev:serial0"
 	deviceLegacySerialSocketString = "-serial unix:/tmp/serial.sock,server=on,wait=off"
-	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom,max_ports=2"
+	deviceSerialString             = "-device virtio-serial-pci,id=serial0,romfile=efi-virtio.rom,disable-modern=true,max_ports=2"
 	deviceVirtioSerialPortString   = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server=on,wait=off"
 	deviceSpiceSerialPortString    = "-device virtserialport,chardev=spicechannel0,name=com.redhat.spice.0 -chardev spicevmc,id=spicechannel0,name=vdagent"
-	devicePCISerialString		   = "-device pci-serial,chardev=serial0"
+	devicePCISerialString		   = "-device pci-serial,id=pciser0,chardev=serial0"
 )
 
 func TestAppendLegacySerialMonMux(t *testing.T) {
@@ -37,7 +37,7 @@ func TestAppendLegacySerialUnix(t *testing.T) {
 
 }
 
-func TestAppendDeviceSerial(t *testing.T) {
+func TestAppendDeviceVirtSerial(t *testing.T) {
 	sdev := SerialDevice{
 		Driver:        VirtioSerial,
 		ID:            "serial0",
@@ -90,10 +90,11 @@ func TestAppendEmptySerialDevice(t *testing.T) {
 	}
 }
 
-func TestAppendPCISerialDevice(t *testing.T) {
-	sdev := PCISerialDevice{
-		ChardevID: "serial0",
+func TestAppendDevicePCISerial(t *testing.T) {
+	sdev := SerialDevice{
+		Driver:        PCISerial,
+		ID:            "pciser0",
+		ChardevID:	   "serial0",
 	}
-
 	testAppend(sdev, devicePCISerialString, t)
 }


### PR DESCRIPTION
Added changes necessary to include `pci-serial` device into qcli as the console was not working with qemu-system-aarch64