### PR TITLE
Refactor uefi arch support and add unittest that doesn't rely on host

### DIFF
--- a/uefi_test.go
+++ b/uefi_test.go
@@ -1,9 +1,12 @@
 package qcli
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
-	//"runtime"
 )
 
 func TestUEFIFirmwareDeviceValid(t *testing.T) {
@@ -32,6 +35,118 @@ func TestAppendUEFIFirmwareDevice(t *testing.T) {
 	testAppend(udev, expected, t)
 }
 
+func createTree(basePath string, files []string) error {
+	for _, file := range files {
+		targetFile := filepath.Join(basePath, file)
+		dir := filepath.Dir(targetFile)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("Failed to create directory %q for file %q: %s", dir, targetFile, err)
+		}
+		fh, err := os.OpenFile(targetFile, os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to create file %q: %s", targetFile, err)
+		}
+		fh.Close()
+		// fmt.Printf("touched %q\n", targetFile)
+	}
+	return nil
+}
+
+func ubuntuVMFFiles() []string {
+	switch runtime.GOARCH {
+	case "amd64", "x86_64":
+		return []string{
+			"OVMF_CODE_4M.fd",
+			"OVMF_CODE_4M.ms.fd",
+			"OVMF_CODE_4M.secboot.fd",
+			"OVMF_CODE.fd",
+			"OVMF_CODE.ms.fd",
+			"OVMF_CODE.secboot.fd",
+			"OVMF_VARS_4M.fd",
+			"OVMF_VARS_4M.ms.fd",
+			"OVMF_VARS.fd",
+			"OVMF_VARS.ms.fd",
+			"OVMF_VARS.snakeoil.fd",
+		}
+	case "arm64", "aarch64":
+		return []string{
+			"AAVMF32_CODE.fd",
+			"AAVMF32_VARS.fd",
+			"AAVMF_CODE.fd",
+			"AAVMF_CODE.ms.fd",
+			"AAVMF_CODE.snakeoil.fd",
+			"AAVMF_VARS.fd",
+			"AAVMF_VARS.ms.fd",
+			"AAVMF_VARS.snakeoil.fd",
+		}
+	}
+	return []string{}
+}
+
+func TestNewUEFIFIrmwareDeviceSecureBoot(t *testing.T) {
+	origVMFHostPrefix := VMFHostPrefix
+	VMFHostPrefix = t.TempDir()
+	defer func() {
+		VMFHostPrefix = origVMFHostPrefix
+	}()
+
+	basePath := VMFPathBase()
+	files := ubuntuVMFFiles()
+	if err := createTree(basePath, files); err != nil {
+		t.Fatalf("Failed to create directory structure for test: %s", err)
+	}
+
+	secureBoot := true
+	udev, err := NewSystemUEFIFirmwareDevice(secureBoot)
+	if err != nil {
+		t.Fatalf("Invalid New UEFI Firwmare device: %s", err)
+	}
+	codePath := ""
+	varsPath := ""
+	switch runtime.GOARCH {
+	case "amd64", "x86_64":
+		codePath = filepath.Join(basePath, "OVMF_CODE_4M.secboot.fd")
+		varsPath = filepath.Join(basePath, "OVMF_VARS_4M.ms.fd")
+	case "arm64", "aarch64":
+		codePath = filepath.Join(basePath, "AAVMF_CODE.ms.fd")
+		varsPath = filepath.Join(basePath, "AAVMF_VARS.ms.fd")
+	}
+	expected := fmt.Sprintf("-drive if=pflash,format=raw,readonly=on,file=%s -drive if=pflash,format=raw,file=%s", codePath, varsPath)
+	testAppend(*udev, expected, t)
+}
+
+func TestNewUEFIFIrmwareDevice(t *testing.T) {
+	origVMFHostPrefix := VMFHostPrefix
+	VMFHostPrefix = t.TempDir()
+	defer func() {
+		VMFHostPrefix = origVMFHostPrefix
+	}()
+
+	basePath := VMFPathBase()
+	files := ubuntuVMFFiles()
+	if err := createTree(basePath, files); err != nil {
+		t.Fatalf("Failed to create directory structure for test: %s", err)
+	}
+
+	secureBoot := false
+	udev, err := NewSystemUEFIFirmwareDevice(secureBoot)
+	if err != nil {
+		t.Fatalf("Invalid New UEFI Firwmare device: %s", err)
+	}
+	codePath := ""
+	varsPath := ""
+	switch runtime.GOARCH {
+	case "amd64", "x86_64":
+		codePath = filepath.Join(basePath, "OVMF_CODE_4M.fd")
+		varsPath = filepath.Join(basePath, "OVMF_VARS_4M.fd")
+	case "arm64", "aarch64":
+		codePath = filepath.Join(basePath, "AAVMF_CODE.fd")
+		varsPath = filepath.Join(basePath, "AAVMF_VARS.fd")
+	}
+	expected := fmt.Sprintf("-drive if=pflash,format=raw,readonly=on,file=%s -drive if=pflash,format=raw,file=%s", codePath, varsPath)
+	testAppend(*udev, expected, t)
+}
+
 func TestAppendUEFIFirmwareDeviceConfig(t *testing.T) {
 	c := &Config{}
 	udev := UEFIFirmwareDevice{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"}
@@ -50,28 +165,5 @@ func TestAppendUEFIFirmwareDeviceConfig(t *testing.T) {
 		t.Fatalf("Failed to append parameters\nexpected[%s]\n!=\nfound   [%s]", expected, result)
 	}
 }
-/* Commented out because success/failure depends on local filesystem
-func TestNewFirmwareDev(t *testing.T) {
-	secureBoot := true
-	udev, err := NewSystemUEFIFirmwareDevice(secureBoot)
-	if err != nil {
-		t.Fatalf("Failed to find secure firmware blobs: %s", err)
-	}
-	switch runtime.GOARCH{
-	case "amd64":
-		if PathExists(UbuntuSecVars) {
-			expected := "-drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.secboot.fd -drive if=pflash,format=raw,file=/usr/share/OVMF/OVMF_VARS.ms.fd"
-			testAppend(*udev, expected, t)
-		} else if PathExists(CentosSecVars){
-			expected := "-drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.secboot.fd -drive if=pflash,format=raw,file=/usr/share/OVMF/OVMF_VARS.secboot.fd"
-			testAppend(*udev, expected, t)
-		} else {
-			t.Fatalf("Failed to find secure firmware blobs")
-		}
-	case "arm64", "aarch64":
-		expected := "-drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.ms.fd -drive if=pflash,format=raw,file=/usr/share/AAVMF/AAVMF_VARS.ms.fd"
-		testAppend(*udev, expected, t)
-	}
-}
-*/
+
 // TODO: add system tests to handle different distros


### PR DESCRIPTION
Break down the construction of UEFI Virtual Firmware paths and file names to easily construct different scenarios and combinations of firmware objects.

- Add runtime.GOARCH to helper functions to abstract the arch difference between amd64 and arm64
- Add firmware device functions
- Introduce a HostPrefix path which enables mocking a host environment for testing firmware selection paths
- Uncomment the NewUefiFirmwareDevice test case which can now run mocked on host systems which don't have the UEFI Firmware packages installed.